### PR TITLE
allow overriding default styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ class MyApp extends React.Component {
 
 Supported props:
 * `hightlightTimeout` — number, default: 1500.
+* `style` — object, override default styles (useful for re-positioning the control panel)
 
 
 From there on, after each rendering a reactive components logs the following three metrics:

--- a/src/Panel/index.jsx
+++ b/src/Panel/index.jsx
@@ -25,7 +25,7 @@ export default class Panel extends Component {
 
     return (
       <div>
-        <div className={css.panel}>
+        <div className={css.panel} style={this.props.style}>
           {/*
            <a
            href="https://mobxjs.github.io/mobx/"

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ export default class DevTool extends Component {
 
   static propTypes = {
     hightlightTimeout: PropTypes.number,
+    style: PropTypes.object,
   };
 
   static defaultProps = {
@@ -156,6 +157,7 @@ export default class DevTool extends Component {
     return (
       <div ref={el => this.containerEl = el}>
         <Panel
+          style={this.props.style}
           updatesEnabled={updatesEnabled}
           graphEnabled={graphEnabled}
           logEnabled={logEnabled}


### PR DESCRIPTION
In my case, the default position of the panel obstucts a dropdown. This allows the panel to be moved to a more convenient location. For example:

``` javascript
<DevTools style={{right: '400px'}} />
```
