### PR TITLE
fix uglifyjs config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,8 +38,8 @@ module.exports = {
       'process.env.NODE_ENV': JSON.stringify('production')
     }),
     new webpack.optimize.UglifyJsPlugin({
-      compressor: {
-        screw_ie8: true,
+      screw_ie8: true,
+      compress: {
         warnings: false
       }
     })


### PR DESCRIPTION
I might be wrong, but the uglifyjs config doesn't seem right. According to the documentation the option should be --compress (not --compressor), and --screw-ie8 should be top-level option, not an option passed to the compressor.
