### PR TITLE
allow configuring panel position

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ class MyApp extends React.Component {
 
 Supported props:
 * `hightlightTimeout` — number, default: 1500.
+* `position` — object, position of control panel, default: {top: 0, right: '20px'}.
 
 
 From there on, after each rendering a reactive components logs the following three metrics:

--- a/src/Panel/index.jsx
+++ b/src/Panel/index.jsx
@@ -15,6 +15,7 @@ export default class Panel extends Component {
 
   render() {
     const {
+      position,
       logEnabled,
       updatesEnabled,
       graphEnabled,
@@ -23,9 +24,20 @@ export default class Panel extends Component {
       onToggleGraph,
     } = this.props;
 
+    let styles;
+    if (position) {
+      styles.top = position.top;
+      styles.right = position.right;
+      styles.bottom = position.bottom;
+      styles.left = position.left;
+    } else {
+      styles.top = '0px';
+      styles.right = '20px';
+    }
+
     return (
       <div>
-        <div className={css.panel}>
+        <div className={css.panel} style={styles}>
           {/*
            <a
            href="https://mobxjs.github.io/mobx/"

--- a/src/Panel/panel.css
+++ b/src/Panel/panel.css
@@ -1,7 +1,5 @@
 :local(.panel) {
     position: fixed;
-    top: 0px;
-    right: 20px;
     height: 26px;
     background-color: #fff;
     color: rgba(0, 0, 0, 0.8);

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ export default class DevTool extends Component {
 
   static propTypes = {
     hightlightTimeout: PropTypes.number,
+    position: PropTypes.object,
   };
 
   static defaultProps = {
@@ -156,6 +157,7 @@ export default class DevTool extends Component {
     return (
       <div ref={el => this.containerEl = el}>
         <Panel
+          position={this.props.position}
           updatesEnabled={updatesEnabled}
           graphEnabled={graphEnabled}
           logEnabled={logEnabled}


### PR DESCRIPTION
The default position of the panel was obstructing a menu so I made this modification to allow the panel to be moved to a more convenient location. For example:

``` javascript
<DevTools position={{bottom:0, right:0}} />
```
