### PR TITLE
Use explicit color for graph boxes

### DIFF
--- a/src/Graph/styles.js
+++ b/src/Graph/styles.js
@@ -35,6 +35,7 @@ export const box = {
     background: 'rgba(0, 0, 0, 0.05)',
     display: 'inline-block',
     marginBottom: '8px',
+    color: '#000',
     root: {
         fontSize: '15px',
         fontWeight: 'bold',


### PR DESCRIPTION
Makes sure that graph text can be seen if parents declare a color that does not contrast well (prevents color cascade from whatever app is using `mobx-react-devtools` if they declare a bad color in `body`).

Before:
![screen shot 2016-10-24 at 10 15 36](https://cloud.githubusercontent.com/assets/65468/19649196/e7a5f938-99d2-11e6-8c87-1fbfe7cbd21f.png)

After:
![screen shot 2016-10-24 at 10 16 00](https://cloud.githubusercontent.com/assets/65468/19649202/eb1e617c-99d2-11e6-8769-94ca6a079db6.png)
