### PR TITLE
Make "updated" message display correct values

### DIFF
--- a/src/consoleLogChange.js
+++ b/src/consoleLogChange.js
@@ -77,7 +77,7 @@ export default function consoleLogChange(change, filter) {
                 } else if (mobx.isObservableObject(change.object)) {
                     logNext("updated '%s.%s': %s (was: %s)", observableName(change.object), change.name, formatValue(change.newValue), formatValue(change.oldValue));
                 } else {
-                    logNext("updated '%s': %s (was: %s)", observableName(change.object), change.name, formatValue(change.newValue), formatValue(change.oldValue));
+                    logNext("updated '%s': %s (was: %s)", observableName(change.object), formatValue(change.newValue), formatValue(change.oldValue));
                 }
                 dir({
                     newValue: change.newValue,


### PR DESCRIPTION
The log message when a non-array/non-object value is updated displays in a way that makes it appear that the change was backwards.

For example, changing an observable value from `null` to `'foo'` logs:

    updated 'ObservableValue@87': undefined (was: foo) null

This is because the log call for this case has 3 placeholders but 4 values, so what you are actually seeing is `undefined` (coming from `change.name`, which appears to always be undefined in this case), which pushes the new value into the `(was: )` comments, and the actual `was` value just gets stuck on the end..