### PR TITLE
Readme typo, `DevTools` should be consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Mind that any log statements that are printed during these (re)actions will appe
 ### Configuration
 
 ```js
-import DevTool, { configureDevtool } from 'mobx-react-devtools';
+import DevTools, { configureDevtool } from 'mobx-react-devtools';
 
 // Any configurations are optional
 configureDevtool({
@@ -85,7 +85,7 @@ setGraphEnabled(false); // same as configureDevtool({ graphEnabled: false });
 ### Custom panel design
 
 ```js
-import DevTool, { GraphControl, LogControl, UpdatesControl } from 'mobx-react-devtools';
+import DevTools, { GraphControl, LogControl, UpdatesControl } from 'mobx-react-devtools';
 
 class MyNiceButton extends React.Component {
   render() {
@@ -105,7 +105,7 @@ class MyApp extends React.Component {
       <div>
 
         {/* Include somewhere with `noPanel` prop. Is needed to display updates and modals */}
-        <DevTool noPanel />
+        <DevTools noPanel />
 
         <div className="my-custom-devtools-panel-design">
           <GraphControl>
@@ -163,7 +163,7 @@ class MyApp extends React.Component {
 * Fixed typescript typings (#36)
 
 4.2.7
-* Fixed passing highlightTimeout from DevTool (#41)
+* Fixed passing highlightTimeout from DevTools (#41)
 
 4.2.6
 * Fixed “max event listeners” warning when rendering in node.js ()


### PR DESCRIPTION
This confused me, so decided to PR