### PR TITLE
Remove trailing comma from .babelrc 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["es2015", "react"],
-  "plugins": ["transform-class-properties"],
+  "plugins": ["transform-class-properties"]
 }


### PR DESCRIPTION
The trailing comma causes Parcel bundler to fail because it cannot parse it.