### PR TITLE
chore: update peer-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     },
     "homepage": "https://mobxjs.github.io/mobx",
     "peerDependencies": {
-        "mobx": "^2.2.0 || ^3.0.0",
-        "mobx-react": "^3.3.0 || ^4.0.0"
+        "mobx": "^2.2.0 || ^3.0.0 || ^4.0.0",
+        "mobx-react": "^3.3.0 || ^4.0.0 || ^5.0.0"
     },
     "devDependencies": {
         "babel": "^6.5.1",


### PR DESCRIPTION
The peer dependencies should include mobx 4 and mobx-react 5