### PR TITLE
Fix compatibility issues with v5+ (backward compatible)

### DIFF
--- a/src/consoleLogChange.js
+++ b/src/consoleLogChange.js
@@ -1,5 +1,7 @@
 import { isObservableArray, isObservableObject, getDebugName } from "mobx"
 
+const mobxAdminProperty = $mobx || "$mobx"
+
 let advisedToUseChrome = false
 
 let currentDepth = 0
@@ -251,8 +253,8 @@ function getNameForThis(who) {
     if (who === null || who === undefined) {
         return ""
     } else if (who && typeof who === "object") {
-        if (who && who.$mobx) {
-            return who.$mobx.name
+        if (who && who[mobxAdminProperty]) {
+            return who[mobxAdminProperty].name
         } else if (who.constructor) {
             return who.constructor.name || "object"
         }

--- a/src/globalStore.js
+++ b/src/globalStore.js
@@ -1,8 +1,10 @@
-import { spy, getDependencyTree } from "mobx"
+import { spy, getDependencyTree, $mobx } from "mobx"
 import { componentByNodeRegistery } from "mobx-react"
 import EventEmmiter from "events"
 import deduplicateDependencies from "./deduplicateDependencies"
 import consoleLogChange from "./consoleLogChange"
+
+const mobxAdminProperty = $mobx || "$mobx"
 
 const LS_UPDATES_KEY = "mobx-react-devtool__updatesEnabled"
 const LS_LOG_KEY = "mobx-react-devtool__logEnabled"
@@ -110,7 +112,7 @@ export const _handleClick = e => {
         if (component) {
             e.stopPropagation()
             e.preventDefault()
-            const dependencyTree = getDependencyTree(component.render.$mobx)
+            const dependencyTree = getDependencyTree(component.render[mobxAdminProperty])
             deduplicateDependencies(dependencyTree)
             setGlobalState({
                 dependencyTree,


### PR DESCRIPTION
This fixes issue with $mobx property replaced with Symbol in v5 - as result showing dependencies tree was broken - mentioned in issues #92 and #91 