### PR TITLE
#92 Mobx 5.0.0 support

### DIFF
--- a/src/consoleLogChange.js
+++ b/src/consoleLogChange.js
@@ -1,4 +1,4 @@
-import { isObservableArray, isObservableObject, getDebugName } from "mobx"
+import { $mobx, isObservableArray, isObservableObject, getDebugName } from "mobx"
 
 let advisedToUseChrome = false
 
@@ -251,8 +251,8 @@ function getNameForThis(who) {
     if (who === null || who === undefined) {
         return ""
     } else if (who && typeof who === "object") {
-        if (who && who.$mobx) {
-            return who.$mobx.name
+        if (who && who[$mobx]) {
+            return who[$mobx].name
         } else if (who.constructor) {
             return who.constructor.name || "object"
         }

--- a/src/globalStore.js
+++ b/src/globalStore.js
@@ -1,4 +1,4 @@
-import { spy, getDependencyTree } from "mobx"
+import { $mobx, spy, getDependencyTree } from "mobx"
 import { componentByNodeRegistery } from "mobx-react"
 import EventEmmiter from "events"
 import deduplicateDependencies from "./deduplicateDependencies"
@@ -110,7 +110,7 @@ export const _handleClick = e => {
         if (component) {
             e.stopPropagation()
             e.preventDefault()
-            const dependencyTree = getDependencyTree(component.render.$mobx)
+            const dependencyTree = getDependencyTree(component.render[$mobx])
             deduplicateDependencies(dependencyTree)
             setGlobalState({
                 dependencyTree,


### PR DESCRIPTION
https://github.com/mobxjs/mobx/blob/master/CHANGELOG.md
.$mobx property has been dropped from all observables and replaced by a Symbol.
Instead of using x.$mobx.name, use import { $mobx } from "mobx"; x[$mobx].name etc.

Fix for 'Cannot obtain atom from undefined' https://github.com/mobxjs/mobx-react-devtools/issues/92