### PR TITLE
Re-add missing isObservableMap import

### DIFF
--- a/src/consoleLogChange.js
+++ b/src/consoleLogChange.js
@@ -1,4 +1,4 @@
-import { $mobx, isObservableArray, isObservableObject, getDebugName } from "mobx"
+import { $mobx, isObservableArray, isObservableObject, isObservableMap, getDebugName } from "mobx"
 
 let advisedToUseChrome = false
 


### PR DESCRIPTION
Somewhere along the merging the `isObservableMap` import disappeared. As it is referenced in code it causes runtime exceptions if the code path get's there.