### PR TITLE
Set position with string & default to bottom right

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+    "blanks-around-lists": false,
+    "line-length": false
+}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ or
 
 Supported props:
 * `highlightTimeout` — number, default: 1500
-* `position` — object, position of control panel, default: `{ top: -2, right: 20 }`
+* `position` — string, `topRight`, `bottomRight`, `bottomLeft` or `topLeft`, default: `bottomRight`
+
+The position of the panel can be tweaked by setting the value to an object with `top`, `right`, `bottom` or `left` defined. Setting it to `{ top: -2, right: 20 }` is the same as `topRight`.
 
 From there on, after each rendering a reactive components logs the following three metrics:
 1. Number of times the component did render so far

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,8 @@ import React = require("react")
 
 export interface IDevToolProps {
     highlightTimeout?: number
-    position?: {
+    position?: "topRight" | "bottomRight" | "bottomLeft" | "topLeft" |
+    {
         top?: number | string
         right?: number | string
         bottom?: number | string

--- a/src/DevTool.js
+++ b/src/DevTool.js
@@ -8,7 +8,15 @@ import Graph from "./Graph"
 export default class DevTool extends Component {
     static propTypes = {
         highlightTimeout: PropTypes.number,
-        position: PropTypes.object,
+        position: PropTypes.oneOfType(
+            PropTypes.oneOf(['topRight', 'bottomRight', 'bottomLeft', 'topLeft']),
+            PropTypes.shape({
+                top: PropTypes.string,
+                right: PropTypes.string,
+                bottom: PropTypes.string,
+                left: PropTypes.string,
+            })
+        ),
         noPanel: PropTypes.bool
     }
 

--- a/src/Panel/index.jsx
+++ b/src/Panel/index.jsx
@@ -28,10 +28,31 @@ export default class Panel extends Component {
 
     const additionalPanelStyles = {};
     if (position) {
-      additionalPanelStyles.top = position.top;
-      additionalPanelStyles.right = position.right;
-      additionalPanelStyles.bottom = position.bottom;
-      additionalPanelStyles.left = position.left;
+      if (typeof position === 'string') {
+        switch (position) {
+          case 'topRight':
+            additionalPanelStyles.top = '-2px';
+            additionalPanelStyles.right = '20px';
+            break;
+          case 'bottomRight':
+            additionalPanelStyles.bottom = '-2px';
+            additionalPanelStyles.right = '20px';
+            break;
+          case 'bottomLeft':
+            additionalPanelStyles.bottom = '-2px';
+            additionalPanelStyles.left = '20px';
+            break;
+          case 'topLeft':
+            additionalPanelStyles.top = '-2px';
+            additionalPanelStyles.left = '20px';
+            break;
+        }
+      } else {
+        additionalPanelStyles.top = position.top;
+        additionalPanelStyles.right = position.right;
+        additionalPanelStyles.bottom = position.bottom;
+        additionalPanelStyles.left = position.left;
+      }
     } else {
       additionalPanelStyles.top = '-2px';
       additionalPanelStyles.right = '20px';

--- a/src/Panel/index.jsx
+++ b/src/Panel/index.jsx
@@ -28,34 +28,33 @@ export default class Panel extends Component {
 
     const additionalPanelStyles = {};
     if (!position) {
-      additionalPanelStyles.top = '-2px';
-      additionalPanelStyles.right = '20px';
-    } else {
-      if (typeof position === 'string') {
-        switch (position) {
-          case 'topRight':
-            additionalPanelStyles.top = '-2px';
-            additionalPanelStyles.right = '20px';
-            break;
-          case 'bottomRight':
-            additionalPanelStyles.bottom = '-2px';
-            additionalPanelStyles.right = '20px';
-            break;
-          case 'bottomLeft':
-            additionalPanelStyles.bottom = '-2px';
-            additionalPanelStyles.left = '20px';
-            break;
-          case 'topLeft':
-            additionalPanelStyles.top = '-2px';
-            additionalPanelStyles.left = '20px';
-            break;
-        }
-      } else {
-        additionalPanelStyles.top = position.top;
-        additionalPanelStyles.right = position.right;
-        additionalPanelStyles.bottom = position.bottom;
-        additionalPanelStyles.left = position.left;
+      position = 'bottomRight'
+    }
+
+    if (typeof position === 'string') {
+      switch (position) {
+        case 'topRight':
+          additionalPanelStyles.top = '-2px';
+          additionalPanelStyles.right = '20px';
+          break;
+        case 'bottomRight':
+          additionalPanelStyles.bottom = '-2px';
+          additionalPanelStyles.right = '20px';
+          break;
+        case 'bottomLeft':
+          additionalPanelStyles.bottom = '-2px';
+          additionalPanelStyles.left = '20px';
+          break;
+        case 'topLeft':
+          additionalPanelStyles.top = '-2px';
+          additionalPanelStyles.left = '20px';
+          break;
       }
+    } else {
+      additionalPanelStyles.top = position.top;
+      additionalPanelStyles.right = position.right;
+      additionalPanelStyles.bottom = position.bottom;
+      additionalPanelStyles.left = position.left;
     }
 
     return (

--- a/src/Panel/index.jsx
+++ b/src/Panel/index.jsx
@@ -27,7 +27,10 @@ export default class Panel extends Component {
     const { position, highlightTimeout } = this.props;
 
     const additionalPanelStyles = {};
-    if (position) {
+    if (!position) {
+      additionalPanelStyles.top = '-2px';
+      additionalPanelStyles.right = '20px';
+    } else {
       if (typeof position === 'string') {
         switch (position) {
           case 'topRight':
@@ -53,9 +56,6 @@ export default class Panel extends Component {
         additionalPanelStyles.bottom = position.bottom;
         additionalPanelStyles.left = position.left;
       }
-    } else {
-      additionalPanelStyles.top = '-2px';
-      additionalPanelStyles.right = '20px';
     }
 
     return (


### PR DESCRIPTION
- Enable setting the position of the panel with a the string `topRight`, `bottomRight`, `bottomLeft` or `topLeft`.
- Default to bottom right corner instead of top right.

The rationale for moving to bottom right by default is that most website place controls in the top right corner (log in information, burger menu, etc.), so having the development tools in the top right corner could easily interfere with the UI of the website. Moving the controls to the bottom right limits the sites where the controls will overlap something, and it will often be possible to move the dev tools out of the way by scrolling on the page.