### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ or
 
 Supported props:
 * `highlightTimeout` — number, default: 1500
-* `noPanel` — boolean, if set, do not render control panel
+* `noPanel` — boolean, if set, do not render control panel, default: false
 * `position` — string or object, `topRight`, `bottomRight`, `bottomLeft` or `topLeft`, default: `bottomRight`
-* `className` — string, className of control panel
-* `style` — object, inline style object of control panel
+* `className` — string, className of control panel, default: not defined
+* `style` — object, inline style object of control panel, default: not defined
 
 The position of the panel can be tweaked by setting the value to an object with `top`, `right`, `bottom` or `left` defined. Setting it to `{ top: -2, right: 20 }` is the same as `topRight`.
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ or
 Supported props:
 * `highlightTimeout` — number, default: 1500
 * `noPanel` — boolean, if set, do not render control panel, default: false
-* `position` — string or object, `topRight`, `bottomRight`, `bottomLeft` or `topLeft`, default: `bottomRight`
+* `position` — string (or object), `topRight`, `bottomRight`, `bottomLeft` or `topLeft`, default: `bottomRight`
 * `className` — string, className of control panel, default: not defined
 * `style` — object, inline style object of control panel, default: not defined
 
-The position of the panel can be tweaked by setting the value to an object with `top`, `right`, `bottom` or `left` defined. Setting it to `{ top: -2, right: 20 }` is the same as `topRight`.
+In order to be compatible with earlier versions of `mobx-react-devtools` it is also possible to assign `position` to an object containing inline styles. Using the dedicated `style` property is however recommended.
 
 From there on, after each rendering a reactive components logs the following three metrics:
 1. Number of times the component did render so far

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ or
 Supported props:
 * `highlightTimeout` — number, default: 1500
 * `noPanel` — boolean, if set, do not render control panel
+* `position` — string or object, `topRight`, `bottomRight`, `bottomLeft` or `topLeft`, default: `bottomRight`
 * `className` — string, className of control panel
 * `style` — object, inline style object of control panel
-* `position` — string or object, `topRight`, `bottomRight`, `bottomLeft` or `topLeft`, default: `bottomRight`
 
 The position of the panel can be tweaked by setting the value to an object with `top`, `right`, `bottom` or `left` defined. Setting it to `{ top: -2, right: 20 }` is the same as `topRight`.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ DevTools for MobX to track the rendering behavior and data dependencies of your 
 
 ![MobX DevTools](devtools.gif)
 
+*The default position of the panel has been changed to bottom right. If you prefer top right like in the gif above, add `position="topRight"` to `<DevTools />`.*
+
 ## Installation
 
 `npm install --save-dev mobx-react-devtools`

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ or
 Supported props:
 * `highlightTimeout` — number, default: 1500
 * `noPanel` — boolean, if set, do not render control panel
-* `position` — object, position of control panel, default: `{ top: -2, right: 20 }`
 * `className` — string, className of control panel
 * `style` — object, inline style object of control panel
 * `position` — string or object, `topRight`, `bottomRight`, `bottomLeft` or `topLeft`, default: `bottomRight`


### PR DESCRIPTION
The `position` property was documented twice after the two latest pull requests were merged. Fixed this and made a couple of other additions. Tried to keep everything in small commits, so that it should be possible to cherry pick the desired changes.