### PR TITLE
Firefox now formats the logs properly (#31)

### DIFF
--- a/src/consoleLogChange.js
+++ b/src/consoleLogChange.js
@@ -1,18 +1,19 @@
 import { $mobx, isObservableArray, isObservableObject, isObservableMap, getDebugName } from "mobx"
 
-let advisedToUseChrome = false
+let advisedToUseModernBrowser = false
 
 let currentDepth = 0
 let isInsideSkippedGroup = false
 
 export default function consoleLogChange(change, filter) {
     if (
-        advisedToUseChrome === false &&
+        advisedToUseModernBrowser === false &&
         typeof navigator !== "undefined" &&
-        navigator.userAgent.indexOf("Chrome") === -1
+        navigator.userAgent.indexOf("Chrome") === -1 &&
+        navigator.userAgent.indexOf("Firefox") === -1
     ) {
-        console.warn("The output of the MobX logger is optimized for Chrome")
-        advisedToUseChrome = true
+        console.warn("The output of the MobX logger is optimized for browsers with a modern console API like Chrome and Firefox")
+        advisedToUseModernBrowser = true
     }
 
     const isGroupStart = change.spyReportStart === true


### PR DESCRIPTION
Update the log message to include Firefox as a workable option now that the output looks fine.

I'm hesitant to change the "Recommended browser" message tooltip since I'm seeing a noticeable performance gap between Chrom(e|ium) and Firefox for logging large changesets. There's an [open bug on Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1468065) which seems related to what I'm seeing.

Should be able to close #31 now regardless, unless you want to keep it around for Edge/others that don't have the needed console APIs.