### PR TITLE
Fix typo in DevTool.js

### DIFF
--- a/src/DevTool.js
+++ b/src/DevTool.js
@@ -10,7 +10,7 @@ export default class DevTool extends Component {
         highlightTimeout: PropTypes.number,
         noPanel: PropTypes.bool,
         className: PropTypes.string,
-        style: propTypes.object,
+        style: PropTypes.object,
         position: PropTypes.oneOfType(
             PropTypes.oneOf(['topRight', 'bottomRight', 'bottomLeft', 'topLeft']),
             PropTypes.shape({


### PR DESCRIPTION
There was a typo in `DevTool.js`'s `style` prop type that was causing issues when running [mobx-react-boilerplate](https://github.com/mobxjs/mobx-react-boilerplate). The browser console output:

```
index.js:1 Uncaught ReferenceError: propTypes is not defined
    at Object.eval (index.js:1)
    at n (index.js:1)
    at Object.eval (index.js:1)
    at n (index.js:1)
    at eval (index.js:1)
    at eval (index.js:1)
    at eval (index.js:1)
    at eval (index.js:1)
    at Object../node_modules/mobx-react-devtools/index.js (bundle.js:1600)
    at __webpack_require__ (bundle.js:1427)
```

This PR corrects this small typo.